### PR TITLE
fix dupe with shulkers for `fabric`

### DIFF
--- a/src/main/java/me/pajic/accessorify/accessories/ShulkerBoxAccessory.java
+++ b/src/main/java/me/pajic/accessorify/accessories/ShulkerBoxAccessory.java
@@ -20,7 +20,7 @@ public class ShulkerBoxAccessory implements Accessory {
     }
 
     @Override
-    public int maxStackSize(ItemStack stack){
+    public int maxStackSize(ItemStack stack) {
         return 1;
     }
 }

--- a/src/main/java/me/pajic/accessorify/accessories/ShulkerBoxAccessory.java
+++ b/src/main/java/me/pajic/accessorify/accessories/ShulkerBoxAccessory.java
@@ -6,6 +6,7 @@ import me.pajic.accessorify.util.ModUtil;
 import me.pajic.accessorify.util.MultiVersionUtil;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.minecraft.world.item.ItemStack;
 
 public class ShulkerBoxAccessory implements Accessory {
 
@@ -16,5 +17,10 @@ public class ShulkerBoxAccessory implements Accessory {
     @Environment(EnvType.CLIENT)
     public static void clientInit() {
         ModUtil.SHULKER_BOXES.forEach(AccessoriesRendererRegistry::registerNoRenderer);
+    }
+
+    @Override
+    public int maxStackSize(ItemStack stack){
+        return 1;
     }
 }


### PR DESCRIPTION
some mods allow stacked shulkers, allowing for an easy dupe when placed in shulker slots