### PR TITLE
fix dupe with shulkers for `neoforge`

### DIFF
--- a/src/main/java/me/pajic/accessorify/accessories/ShulkerBoxAccessory.java
+++ b/src/main/java/me/pajic/accessorify/accessories/ShulkerBoxAccessory.java
@@ -3,10 +3,16 @@ package me.pajic.accessorify.accessories;
 import io.wispforest.accessories.api.Accessory;
 import me.pajic.accessorify.util.ModUtil;
 import me.pajic.accessorify.util.MultiVersionUtil;
+import net.minecraft.world.item.ItemStack;
 
 public class ShulkerBoxAccessory implements Accessory {
 
     public static void init() {
         ModUtil.SHULKER_BOXES.forEach(item -> MultiVersionUtil.registerAccessory(item, new ShulkerBoxAccessory()));
+    }
+
+    @Override
+    public int maxStackSize(ItemStack stack){
+        return 1;
     }
 }

--- a/src/main/java/me/pajic/accessorify/accessories/ShulkerBoxAccessory.java
+++ b/src/main/java/me/pajic/accessorify/accessories/ShulkerBoxAccessory.java
@@ -12,7 +12,7 @@ public class ShulkerBoxAccessory implements Accessory {
     }
 
     @Override
-    public int maxStackSize(ItemStack stack){
+    public int maxStackSize(ItemStack stack) {
         return 1;
     }
 }


### PR DESCRIPTION
some mods allow stacked shulkers, allowing for an easy dupe when placed in shulker slots