### PR TITLE
Add config and condition to elytra flight cancel in liquid for `fabric`

### DIFF
--- a/src/main/java/me/pajic/accessorify/config/ModConfig.java
+++ b/src/main/java/me/pajic/accessorify/config/ModConfig.java
@@ -20,6 +20,7 @@ public class ModConfig extends Config {
     public AccessorySettings accessorySettings = new AccessorySettings();
     public InfoOverlaySettings infoOverlaySettings = new InfoOverlaySettings();
     public ValidatedBoolean hideDebugInfoInSurvival = new ValidatedBoolean(false);
+    public ValidatedBoolean cancelElytraFlyingInLiquid = new ValidatedBoolean(true);
 
     @RequiresAction(action = Action.RESTART)
     public static class AccessorySettings extends ConfigSection {

--- a/src/main/java/me/pajic/accessorify/mixin/PlayerMixin.java
+++ b/src/main/java/me/pajic/accessorify/mixin/PlayerMixin.java
@@ -72,7 +72,9 @@ public abstract class PlayerMixin extends LivingEntity {
     )
     private void cancelElytraFlyingInLiquid(CallbackInfo ci) {
         if (
-                (isInWater() || isInLava()) && (
+                Main.CONFIG.cancelElytraFlyingInLiquid.get() &&
+                (isInWater() || isInLava()) &&
+                isFallFlying() && (
                         //? if <= 1.21.1
                         getItemBySlot(EquipmentSlot.CHEST).getItem() instanceof ElytraItem ||
                         //? if > 1.21.1

--- a/src/main/resources/assets/accessorify/lang/en_us.json
+++ b/src/main/resources/assets/accessorify/lang/en_us.json
@@ -24,6 +24,7 @@
   "accessorify.config.accessorySettings.calendarAccessory.desc": "Requires Serene Seasons or Fabric Seasons + Extras. If you have a season mod installed but want the vanilla clock to show the season instead, turn this option off.",
   "accessorify.config.hideDebugInfoInSurvival": "Hide gameplay info from F3 menu in survival",
   "accessorify.config.hideDebugInfoInSurvival.desc": "This hides most gameplay related info such as coordinates, biome etc. from the F3 debug screen. Used to make the compass and clock the only source of gameplay information, for immersion.",
+  "accessorify.config.cancelElytraFlyingInLiquid": "Cancel elytra flight when inside a liquid",
   "accessorify.client_config.widgetSettings": "Widget settings",
   "accessorify.client_config.widgetSettings.desc": "Configure the behavior of the shulker box and arrow selection widgets.",
   "accessorify.client_config.widgetSettings.showUIHints": "Show widget keybind hints",

--- a/src/main/resources/assets/accessorify/lang/es_mx.json
+++ b/src/main/resources/assets/accessorify/lang/es_mx.json
@@ -22,6 +22,7 @@
   "accessorify.config.accessorySettings.calendarAccessory.desc": "Requiere Serene Seasons o Fabric Seasons + Extras. Si tienes un mod de estaciones instalado pero quieres que el reloj de vainilla muestre la estación en su lugar, deshabilita esta opción.",
   "accessorify.config.hideDebugInfoInSurvival": "Ocultar información de juego del menú F3 en supervivencia",
   "accessorify.config.hideDebugInfoInSurvival.desc": "Esto oculta la mayor parte de la información de juego, como coordenadas, bioma, etc. del menú de depuración F3. Se usa para hacer que la brújula y el reloj sean la única fuente de información de juego, para mayor inmersión.",
+  "accessorify.config.cancelElytraFlyingInLiquid": "Cancel elytra flight when inside a liquid",
   "accessorify.client_config.widgetSettings": "Widget settings",
   "accessorify.client_config.widgetSettings.desc": "Configure the behavior of the shulker box and arrow selection widgets.",
   "accessorify.client_config.widgetSettings.showUIHints": "Show widget keybind hints",

--- a/src/main/resources/assets/accessorify/lang/ru_ru.json
+++ b/src/main/resources/assets/accessorify/lang/ru_ru.json
@@ -24,6 +24,7 @@
   "accessorify.config.accessorySettings.calendarAccessory.desc": "Требует Serene Seasons или Fabric Seasons + Extras. Если у вас установлен мод, добавляющий сезоны, но вы хотите, чтобы ванильные часы показывали сезон, отключите эту опцию.",
   "accessorify.config.hideDebugInfoInSurvival": "Скрыть информацию об игровом процессе из меню F3 в режиме выживания",
   "accessorify.config.hideDebugInfoInSurvival.desc": "Скрывает большую часть информации об игре: координаты, биом и т.д. с экрана отладки F3. Используется для того, чтобы компас и часы были единственными источниками информации для большего погружения.",
+  "accessorify.config.cancelElytraFlyingInLiquid": "Cancel elytra flight when inside a liquid",
   "accessorify.client_config.widgetSettings": "Настройки виджетов",
   "accessorify.client_config.widgetSettings.desc": "Настройте поведение виджетов шалкеровых ящиков и стрел.",
   "accessorify.client_config.widgetSettings.showUIHints": "Показывать подсказки клавиш в виджете",


### PR DESCRIPTION
Prevents calling `stopFallFlying()` in `cancelElytraFlyingInLiquid` if the player is not fall flying, fixing an incompatibility with Enderscape (https://github.com/they-made-enderscape/enderscape/issues/84).

Also adds a config to disable entirely, since it modifies vanilla behavior.