### PR TITLE
Netherite Extras and RSB compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ runs
 run-data
 
 repo
+/versions/1.21.1/fabric-remaps/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Removed ability to load shulker boxes into crossbows (this was definitely an intended feature).
+- Added compat for multiple Fabric mods that have compats on the Fabric version. 

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ repositories {
     maven { url 'https://maven.fabricmc.net' }
     maven { url 'https://maven.bawnorton.com/releases' }
     maven { url 'https://maven.shedaniel.me/' }
+    maven {
+        name = "Sinytra"
+        url = "https://maven.sinytra.org/"
+    }
     exclusiveContent {
         forRepository {
             maven {
@@ -96,6 +100,7 @@ dependencies {
     compileOnly "maven.modrinth:fragmentum:${property("fragmentum_version")}"
     compileOnly "maven.modrinth:ars-elixirum:${property("arselixirum_version")}"
     compileOnly "maven.modrinth:extrasoundsforge:${property("extrasounds_version")}"
+    compileOnly files("fabric-remaps/").getAsFileTree()
 }
 
 tasks.withType(ProcessResources).configureEach {

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,9 @@ friendsandfoes_version=[VERSIONED]
 fragmentum_version=[VERSIONED]
 arselixirum_version=[VERSIONED]
 aileron_version=[VERSIONED]
-
+netheriteextras_version=[VERSIONED]
+connector_version=[VERSIONED]
+ffapi_version=[VERSIONED]
 ## Mod Properties
 
 # The unique mod identifier for the mod. Must be lowercase in English locale. Must fit the regex [a-z][a-z0-9_]{1,63}
@@ -46,7 +48,7 @@ mod_name=Accessorify
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=MIT
 # The mod version. See https://semver.org/
-mod_version=2.3.6
+mod_version=2.3.7
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,8 +36,6 @@ fragmentum_version=[VERSIONED]
 arselixirum_version=[VERSIONED]
 aileron_version=[VERSIONED]
 netheriteextras_version=[VERSIONED]
-connector_version=[VERSIONED]
-ffapi_version=[VERSIONED]
 ## Mod Properties
 
 # The unique mod identifier for the mod. Must be lowercase in English locale. Must fit the regex [a-z][a-z0-9_]{1,63}

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,4 +21,3 @@ stonecutter {
         vcsVersion = "1.21.1"
     }
 }
-include '1.21.1-Connector-Remap'

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,10 @@ pluginManagement {
         mavenLocal()
         gradlePluginPortal()
         maven { url = 'https://maven.neoforged.net/releases' }
+        maven {
+            name = "Sinytra"
+            url = "https://maven.sinytra.org/"
+        }
     }
 }
 
@@ -17,3 +21,4 @@ stonecutter {
         vcsVersion = "1.21.1"
     }
 }
+include '1.21.1-Connector-Remap'

--- a/src/main/java/me/pajic/accessorify/ClientMain.java
+++ b/src/main/java/me/pajic/accessorify/ClientMain.java
@@ -27,6 +27,7 @@ import net.neoforged.neoforge.common.NeoForge;
 //? if <= 1.21.1 {
 import me.pajic.accessorify.compat.arselixirum.WitchTotemOfUndyingAccessory;
 import me.pajic.accessorify.compat.deeperdarker.DeeperDarkerCompat;
+import me.pajic.accessorify.compat.netheriteextras.TotemOfNeverdyingAccessory;
 //?}
 import net.neoforged.neoforge.event.TagsUpdatedEvent;
 
@@ -43,8 +44,10 @@ public class ClientMain {
         modEventBus.addListener(SereneSeasonsCalendarAccessory::clientInit);
         modEventBus.addListener(TotemOfFreezingAccessory::clientInit);
         modEventBus.addListener(TotemOfIllusionAccessory::clientInit);
-        //? if <= 1.21.1
+        //? if <= 1.21.1 {
         modEventBus.addListener(WitchTotemOfUndyingAccessory::clientInit);
+        modEventBus.addListener(TotemOfNeverdyingAccessory::clientInit);
+        //?}
         modEventBus.addListener(ModKeybinds::registerKeybinds);
     }
 

--- a/src/main/java/me/pajic/accessorify/Main.java
+++ b/src/main/java/me/pajic/accessorify/Main.java
@@ -18,6 +18,7 @@ import net.neoforged.neoforge.common.NeoForge;
 //? if <= 1.21.1 {
 import me.pajic.accessorify.compat.deeperdarker.SoulElytraAccessory;
 import me.pajic.accessorify.compat.arselixirum.WitchTotemOfUndyingAccessory;
+import me.pajic.accessorify.compat.netheriteextras.TotemOfNeverdyingAccessory;
 //?}
 
 @Mod("accessorify")
@@ -36,8 +37,10 @@ public class Main {
         modEventBus.addListener(SereneSeasonsCalendarAccessory::init);
         modEventBus.addListener(TotemOfFreezingAccessory::init);
         modEventBus.addListener(TotemOfIllusionAccessory::init);
-        //? if <= 1.21.1
+        //? if <= 1.21.1 {
         modEventBus.addListener(WitchTotemOfUndyingAccessory::init);
+        modEventBus.addListener(TotemOfNeverdyingAccessory::init);
+        //?}
     }
 
     public void onInitialize(FMLCommonSetupEvent event) {

--- a/src/main/java/me/pajic/accessorify/datapacks/ModDatapacks.java
+++ b/src/main/java/me/pajic/accessorify/datapacks/ModDatapacks.java
@@ -109,6 +109,16 @@ public class ModDatapacks {
                         Pack.Position.TOP
                 );
             }
+            if (CompatFlags.NETHERITE_EXTRAS_LOADED) {
+                event.addPackFinders(
+                        MultiVersionUtil.withModNamespace(pathPrefix + "totemofneverdying"),
+                        PackType.SERVER_DATA,
+                        Component.literal("Accessorify Totem of Neverdying"),
+                        PackSource.BUILT_IN,
+                        true,
+                        Pack.Position.TOP
+                );
+            }
         }
         if (Main.CONFIG.accessorySettings.enderChestAccessory.get()) event.addPackFinders(
                 MultiVersionUtil.withModNamespace(pathPrefix + "enderchest"),
@@ -126,14 +136,26 @@ public class ModDatapacks {
                 true,
                 Pack.Position.TOP
         );
-        if (Main.CONFIG.accessorySettings.shulkerBoxAccessory.get()) event.addPackFinders(
-                MultiVersionUtil.withModNamespace(pathPrefix + "shulkerbox"),
-                PackType.SERVER_DATA,
-                Component.literal("Accessorify Shulker Box"),
-                PackSource.BUILT_IN,
-                true,
-                Pack.Position.TOP
-        );
+        if (Main.CONFIG.accessorySettings.shulkerBoxAccessory.get()) {
+            event.addPackFinders(
+                    MultiVersionUtil.withModNamespace(pathPrefix + "shulkerbox"),
+                    PackType.SERVER_DATA,
+                    Component.literal("Accessorify Shulker Box"),
+                    PackSource.BUILT_IN,
+                    true,
+                    Pack.Position.TOP
+            );
+            if (CompatFlags.REINFORCED_SHULKERS_LOADED) {
+                event.addPackFinders(
+                        MultiVersionUtil.withModNamespace(pathPrefix + "reinfshulker"),
+                        PackType.SERVER_DATA,
+                        Component.literal("Accessorify Reinforced Shulker"),
+                        PackSource.BUILT_IN,
+                        true,
+                        Pack.Position.TOP
+                );
+            }
+        }
         if (Main.CONFIG.accessorySettings.arrowAccessory.get()) event.addPackFinders(
                 MultiVersionUtil.withModNamespace(pathPrefix + "arrow"),
                 PackType.SERVER_DATA,

--- a/src/main/java/me/pajic/accessorify/menu/ShulkerBoxAccessoryContainerMenu.java
+++ b/src/main/java/me/pajic/accessorify/menu/ShulkerBoxAccessoryContainerMenu.java
@@ -1,5 +1,6 @@
 package me.pajic.accessorify.menu;
 
+import me.pajic.accessorify.util.compat.CompatFlags;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.network.chat.Component;
@@ -17,17 +18,26 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 //? if >= 1.21.10
 /*import net.minecraft.world.entity.ContainerUser;*/
+//? if <= 1.21.1
+import me.pajic.accessorify.compat.reinfshulker.ReinfShulkerCompat;
 
 public class ShulkerBoxAccessoryContainerMenu implements Container, MenuProvider {
 
     private final ItemStack shulker;
     protected NonNullList<ItemStack> items;
 
-    public ShulkerBoxAccessoryContainerMenu(ItemStack shulker) {
+    //? if > 1.21.1 {
+    /*public ShulkerBoxAccessoryContainerMenu(ItemStack shulker) {
         this.shulker = shulker;
         this.items = NonNullList.withSize(27, ItemStack.EMPTY);
     }
-
+    *///?}
+    //? if <= 1.21.1 {
+    public ShulkerBoxAccessoryContainerMenu(ItemStack shulker, int size) {
+        this.shulker = shulker;
+        this.items = NonNullList.withSize(size, ItemStack.EMPTY);
+    }
+    //?}
     //? if < 1.21.10 {
     @Override
     public void startOpen(@NotNull Player player) {
@@ -110,6 +120,11 @@ public class ShulkerBoxAccessoryContainerMenu implements Container, MenuProvider
 
     @Override
     public @Nullable AbstractContainerMenu createMenu(int i, @NotNull Inventory inventory, @NotNull Player player) {
-        return new ShulkerBoxMenu(i, inventory, this);
+        //? if > 1.21.1
+        /*return new ShulkerBoxMenu(i, inventory, this);*/
+        //? if <= 1.21.1 {
+        if (CompatFlags.REINFORCED_SHULKERS_LOADED) return ReinfShulkerCompat.createMenu(i, inventory, this, shulker.getItem());
+        else return new ShulkerBoxMenu(i, inventory, this);
+        //?}
     }
 }

--- a/src/main/java/me/pajic/accessorify/network/ModNetworking.java
+++ b/src/main/java/me/pajic/accessorify/network/ModNetworking.java
@@ -5,6 +5,7 @@ import me.pajic.accessorify.access.SelectedAccessorySlotAccess;
 import me.pajic.accessorify.keybind.ModScrollHandler;
 import me.pajic.accessorify.menu.ShulkerBoxAccessoryContainerMenu;
 import me.pajic.accessorify.util.MultiVersionUtil;
+import me.pajic.accessorify.util.compat.CompatFlags;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.ByteBufCodecs;
@@ -17,12 +18,14 @@ import net.minecraft.world.SimpleMenuProvider;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ChestMenu;
 import net.minecraft.world.inventory.PlayerEnderChestContainer;
+import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 import org.jetbrains.annotations.NotNull;
-
 import java.util.Optional;
+//? if <= 1.21.1
+import me.pajic.accessorify.compat.reinfshulker.ReinfShulkerCompat;
 
 public class ModNetworking {
 
@@ -119,10 +122,20 @@ public class ModNetworking {
                 (payload, context) -> {
                     Player player = context.player();
                     Optional<AccessoriesCapability> ac = AccessoriesCapability.getOptionally(player);
-                    if (ac.isPresent()) {
+                    //? if > 1.21.1 {
+                    /*if (ac.isPresent()) {
                         player.openMenu(new ShulkerBoxAccessoryContainerMenu(ac.get().getContainers().get("shulker").getAccessories().getItem(payload.index)));
                         player.awardStat(Stats.OPEN_SHULKER_BOX);
                     }
+                    *///?}
+                    //? if <= 1.21.1 {
+                    if (ac.isPresent()) {
+                        ItemStack shulker = ac.get().getContainers().get("shulker").getAccessories().getItem(payload.index);
+                        int size = (CompatFlags.REINFORCED_SHULKERS_LOADED) ? ReinfShulkerCompat.getInventorySizeForReinfShulker(shulker.getItem()) : 27;
+                        player.openMenu(new ShulkerBoxAccessoryContainerMenu(shulker, size));
+                        player.awardStat(Stats.OPEN_SHULKER_BOX);
+                    }
+                    //?}
                 }
         );
         registrar.playToServer(

--- a/src/main/java/me/pajic/accessorify/util/ModUtil.java
+++ b/src/main/java/me/pajic/accessorify/util/ModUtil.java
@@ -19,6 +19,7 @@ import net.minecraft.world.item.ProjectileWeaponItem;
 import me.pajic.accessorify.compat.deeperdarker.DeeperDarkerCompat;
 import me.pajic.accessorify.compat.arselixirum.ArsElixirumCompat;
 import me.pajic.accessorify.util.compat.FriendsAndFoesCompat;
+import me.pajic.accessorify.compat.netheriteextras.NetheriteExtrasCompat;
 //?}
 
 import java.util.ArrayList;
@@ -105,13 +106,22 @@ public class ModUtil {
     }
 
     public static boolean isTotem(ItemStack stack) {
-        //? if <= 1.21.1 {
-        if (CompatFlags.FRIENDS_AND_FOES_LOADED && CompatFlags.ARS_ELIXIRUM_LOADED) {
+        //? if 1.21.1 {
+        
+        if (CompatFlags.FRIENDS_AND_FOES_LOADED && CompatFlags.ARS_ELIXIRUM_LOADED && CompatFlags.NETHERITE_EXTRAS_LOADED) {
+            return FriendsAndFoesCompat.isTotem(stack) || ArsElixirumCompat.isTotem(stack) || NetheriteExtrasCompat.isTotem(stack) || stack.is(Items.TOTEM_OF_UNDYING);
+        } else if (CompatFlags.FRIENDS_AND_FOES_LOADED && CompatFlags.ARS_ELIXIRUM_LOADED) {
             return FriendsAndFoesCompat.isTotem(stack) || ArsElixirumCompat.isTotem(stack) || stack.is(Items.TOTEM_OF_UNDYING);
+        } else if (CompatFlags.ARS_ELIXIRUM_LOADED && CompatFlags.NETHERITE_EXTRAS_LOADED) {
+            return ArsElixirumCompat.isTotem(stack) || NetheriteExtrasCompat.isTotem(stack) || stack.is(Items.TOTEM_OF_UNDYING);
+        } else if (CompatFlags.FRIENDS_AND_FOES_LOADED && CompatFlags.NETHERITE_EXTRAS_LOADED) {
+            return FriendsAndFoesCompat.isTotem(stack) || NetheriteExtrasCompat.isTotem(stack) || stack.is(Items.TOTEM_OF_UNDYING);
         } else if (CompatFlags.ARS_ELIXIRUM_LOADED) {
             return ArsElixirumCompat.isTotem(stack) || stack.is(Items.TOTEM_OF_UNDYING);
         } else if (CompatFlags.FRIENDS_AND_FOES_LOADED) {
             return FriendsAndFoesCompat.isTotem(stack) || stack.is(Items.TOTEM_OF_UNDYING);
+        } else if (CompatFlags.NETHERITE_EXTRAS_LOADED) {
+            return NetheriteExtrasCompat.isTotem(stack) || stack.is(Items.TOTEM_OF_UNDYING);
         }
         return stack.is(Items.TOTEM_OF_UNDYING);
         //?}

--- a/src/main/java/me/pajic/accessorify/util/compat/CompatFlags.java
+++ b/src/main/java/me/pajic/accessorify/util/compat/CompatFlags.java
@@ -9,6 +9,8 @@ public class CompatFlags {
     public static final boolean SERENE_SEASONS_LOADED = ModList.get().isLoaded("sereneseasons");
     public static final boolean FRIENDS_AND_FOES_LOADED = ModList.get().isLoaded("friendsandfoes");
     public static final boolean ARS_ELIXIRUM_LOADED = ModList.get().isLoaded("elixirum");
+    public static final boolean NETHERITE_EXTRAS_LOADED = ModList.get().isLoaded("netheriteextras");
+    public static final boolean REINFORCED_SHULKERS_LOADED = ModList.get().isLoaded("reinfshulker");
     public static final boolean ADDITIONAL_LANTERNS_LOADED = ModList.get().isLoaded("additionallanterns");
     public static final boolean IMMERSIVE_OVERLAYS_LOADED = ModList.get().isLoaded("immersiveoverlays");
 }

--- a/src/main/resources/default/reinfshulker/data/accessories/tags/item/shulker.json
+++ b/src/main/resources/default/reinfshulker/data/accessories/tags/item/shulker.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "#reinfshulker:copper_shulker_boxes",
+	"#reinfshulker:diamond_shulker_boxes",
+	"#reinfshulker:gold_shulker_boxes",
+	"#reinfshulker:iron_shulker_boxes",
+	"#reinfshulker:netherite_shulker_boxes"
+  ]
+}

--- a/src/main/resources/default/reinfshulker/pack.mcmeta
+++ b/src/main/resources/default/reinfshulker/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 48,
+    "description": "Accessorify Reinforced Shulker"
+  }
+}

--- a/src/main/resources/default/totemofneverdying/data/accessories/tags/item/charm.json
+++ b/src/main/resources/default/totemofneverdying/data/accessories/tags/item/charm.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "netheriteextras:totem_of_neverdying"
+  ]
+}

--- a/src/main/resources/default/totemofneverdying/pack.mcmeta
+++ b/src/main/resources/default/totemofneverdying/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 48,
+    "description": "Accessorify Totem of Neverdying"
+  }
+}

--- a/src/main/resources/unique/reinfshulker/data/accessories/tags/item/shulker.json
+++ b/src/main/resources/unique/reinfshulker/data/accessories/tags/item/shulker.json
@@ -1,0 +1,10 @@
+{
+  "replace": false,
+  "values": [
+    "#reinfshulker:copper_shulker_boxes",
+	"#reinfshulker:diamond_shulker_boxes",
+	"#reinfshulker:gold_shulker_boxes",
+	"#reinfshulker:iron_shulker_boxes",
+	"#reinfshulker:netherite_shulker_boxes"
+  ]
+}

--- a/src/main/resources/unique/reinfshulker/pack.mcmeta
+++ b/src/main/resources/unique/reinfshulker/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 48,
+    "description": "Accessorify Reinforced Shulker"
+  }
+}

--- a/src/main/resources/unique/totemofneverdying/data/accessories/tags/item/totem.json
+++ b/src/main/resources/unique/totemofneverdying/data/accessories/tags/item/totem.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "netheriteextras:totem_of_neverdying"
+  ]
+}

--- a/src/main/resources/unique/totemofneverdying/pack.mcmeta
+++ b/src/main/resources/unique/totemofneverdying/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 48,
+    "description": "Accessorify Totem of Neverdying"
+  }
+}

--- a/versions/1.21.1/gradle.properties
+++ b/versions/1.21.1/gradle.properties
@@ -17,3 +17,6 @@ arselixirum_version=0.2.2-neoforge
 fragmentum_version=0.0.13-neoforge
 extrasounds_version=1.4-neoforge,1.21.1
 aileron_version=1.21.1-neoforge-1.1.4
+netheriteextras_version=0.4.0+mc1.21
+connector_version=2.0.0-beta.11+1.21.1
+ffapi_version=0.115.6+2.1.4+1.21.1

--- a/versions/1.21.1/gradle.properties
+++ b/versions/1.21.1/gradle.properties
@@ -18,5 +18,3 @@ fragmentum_version=0.0.13-neoforge
 extrasounds_version=1.4-neoforge,1.21.1
 aileron_version=1.21.1-neoforge-1.1.4
 netheriteextras_version=0.4.0+mc1.21
-connector_version=2.0.0-beta.11+1.21.1
-ffapi_version=0.115.6+2.1.4+1.21.1

--- a/versions/1.21.1/src/main/java/me/pajic/accessorify/compat/netheriteextras/NetheriteExtrasCompat.java
+++ b/versions/1.21.1/src/main/java/me/pajic/accessorify/compat/netheriteextras/NetheriteExtrasCompat.java
@@ -1,0 +1,11 @@
+package me.pajic.accessorify.compat.netheriteextras;
+
+import net.minecraft.world.item.ItemStack;
+import xyz.hafemann.netheriteextras.item.ModItems;
+
+public class NetheriteExtrasCompat {
+
+    public static boolean isTotem(ItemStack stack) {
+        return stack.is(ModItems.TOTEM_OF_NEVERDYING);
+    }
+}

--- a/versions/1.21.1/src/main/java/me/pajic/accessorify/compat/netheriteextras/TotemOfNeverdyingAccessory.java
+++ b/versions/1.21.1/src/main/java/me/pajic/accessorify/compat/netheriteextras/TotemOfNeverdyingAccessory.java
@@ -1,0 +1,49 @@
+package me.pajic.accessorify.compat.netheriteextras;
+
+import io.wispforest.accessories.api.client.AccessoriesRendererRegistry;
+import io.wispforest.accessories.api.slot.SlotReference;
+import me.pajic.accessorify.accessories.SlotCopyingAccessory;
+import me.pajic.accessorify.util.ModUtil;
+import me.pajic.accessorify.util.MultiVersionUtil;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.registries.ModifyRegistriesEvent;
+import net.neoforged.neoforge.registries.callback.AddCallback;
+
+public class TotemOfNeverdyingAccessory implements SlotCopyingAccessory {
+
+    @SubscribeEvent
+    public static void init(ModifyRegistriesEvent event) {
+        event.getRegistry(Registries.ITEM).addCallback((AddCallback<Item>) (registry, id, key, value) -> {
+            if (key.location().equals(MultiVersionUtil.parse("netheriteextras:totem_of_neverdying"))) {
+                MultiVersionUtil.registerAccessory(value, new TotemOfNeverdyingAccessory());
+            }
+        });
+    }
+
+    @SubscribeEvent
+    public static void clientInit(ModifyRegistriesEvent event) {
+        event.getRegistry(Registries.ITEM).addCallback((AddCallback<Item>) (registry, id, key, value) -> {
+            if (key.location().equals(MultiVersionUtil.parse("netheriteextras:totem_of_neverdying"))) {
+                AccessoriesRendererRegistry.registerNoRenderer(value);
+            }
+        });
+    }
+
+    @Override
+    public String getPath() {
+        return "add_charm_6";
+    }
+
+    @Override
+    public String getSlot() {
+        return "charm";
+    }
+
+    @Override
+    public boolean canEquip(ItemStack stack, SlotReference reference) {
+        return !MultiVersionUtil.isAnotherEquipped(stack, reference, ModUtil::isTotem);
+    }
+}

--- a/versions/1.21.1/src/main/java/me/pajic/accessorify/compat/reinfshulker/ReinfShulkerCompat.java
+++ b/versions/1.21.1/src/main/java/me/pajic/accessorify/compat/reinfshulker/ReinfShulkerCompat.java
@@ -1,0 +1,33 @@
+package me.pajic.accessorify.compat.reinfshulker;
+
+import atonkish.reinfcore.screen.ReinforcedStorageScreenHandler;
+import atonkish.reinfcore.util.ReinforcingMaterial;
+import atonkish.reinfshulker.item.ModItems;
+import me.pajic.accessorify.menu.ShulkerBoxAccessoryContainerMenu;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ShulkerBoxMenu;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.item.Item;
+
+import java.util.Map;
+
+public class ReinfShulkerCompat {
+    public static int getInventorySizeForReinfShulker(Item shulker) {
+        for (Map.Entry<ReinforcingMaterial, Map<DyeColor, Item>> entry : ModItems.REINFORCED_SHULKER_BOX_MAP.entrySet()) {
+            if (entry.getValue().containsValue(shulker)) return entry.getKey().getSize();
+        }
+        return 27;
+    }
+
+    public static AbstractContainerMenu createMenu(int syncId, Inventory inventory, ShulkerBoxAccessoryContainerMenu menu, Item shulker) {
+        ReinforcingMaterial material = null;
+        for (Map.Entry<ReinforcingMaterial, Map<DyeColor, Item>> entry : ModItems.REINFORCED_SHULKER_BOX_MAP.entrySet()) {
+            if (entry.getValue().containsValue(shulker)) {
+                material = entry.getKey();
+                break;
+            }
+        }
+        return material != null ? ReinforcedStorageScreenHandler.createShulkerBoxScreen(material, syncId, inventory, menu) : new ShulkerBoxMenu(syncId, inventory, menu);
+    }
+}

--- a/versions/1.21.1/src/main/java/me/pajic/accessorify/mixin/compat/netheriteextras/ModEventsMixin.java
+++ b/versions/1.21.1/src/main/java/me/pajic/accessorify/mixin/compat/netheriteextras/ModEventsMixin.java
@@ -1,0 +1,32 @@
+package me.pajic.accessorify.mixin.compat.netheriteextras;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
+import me.pajic.accessorify.Main;
+import me.pajic.accessorify.util.ModUtil;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import xyz.hafemann.netheriteextras.event.ModEvents;
+import xyz.hafemann.netheriteextras.item.ModItems;
+@IfModLoaded("netheriteextras")
+@Mixin(ModEvents.class)
+public class ModEventsMixin {
+
+    @ModifyExpressionValue(
+            method = "lambda$registerModEvents$1",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/LivingEntity;getItemInHand(Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/item/ItemStack;"
+            )
+    )
+    private static ItemStack tryConsumeTotemAccessory(ItemStack original, @Local(argsOnly = true) LivingEntity livingEntity) {
+        if (Main.CONFIG.accessorySettings.totemOfUndyingAccessory.get()) {
+            ItemStack itemStack = ModUtil.getAccessoryStack(livingEntity, ModItems.TOTEM_OF_NEVERDYING).right();
+            return itemStack.isEmpty() ? original : itemStack;
+        }
+        return original;
+    }
+}

--- a/versions/1.21.1/src/main/java/me/pajic/accessorify/mixin/compat/netheriteextras/TotemFloatingDisplayMixin.java
+++ b/versions/1.21.1/src/main/java/me/pajic/accessorify/mixin/compat/netheriteextras/TotemFloatingDisplayMixin.java
@@ -1,0 +1,39 @@
+package me.pajic.accessorify.mixin.compat.netheriteextras;
+
+import com.moulberry.mixinconstraints.annotations.IfModLoaded;
+import me.pajic.accessorify.Main;
+import me.pajic.accessorify.util.ModUtil;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import xyz.hafemann.netheriteextras.item.ModItems;
+@IfModLoaded("netheriteextras")
+@Mixin(ClientPacketListener.class)
+public class TotemFloatingDisplayMixin {
+    @Inject(
+            method = "findTotem",
+            at = {@At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/player/Player;getItemInHand(Lnet/minecraft/world/InteractionHand;)Lnet/minecraft/world/item/ItemStack;"
+            )},
+            cancellable = true
+    )
+    private static void onGetActiveTotemOfUndying(Player player, CallbackInfoReturnable<ItemStack> cir) {
+        InteractionHand[] hands = InteractionHand.values();
+
+        for (InteractionHand hand : hands) {
+            if (Main.CONFIG.accessorySettings.totemOfUndyingAccessory.get()) {
+                ItemStack itemStack = ModUtil.getAccessoryStack(player, ModItems.TOTEM_OF_NEVERDYING).right();
+                if (itemStack.is(ModItems.TOTEM_OF_NEVERDYING)) {
+                    cir.setReturnValue(itemStack);
+                }
+            }
+
+        }
+    }
+}

--- a/versions/1.21.1/src/main/resources/accessorify.mixins.json
+++ b/versions/1.21.1/src/main/resources/accessorify.mixins.json
@@ -17,7 +17,8 @@
     "compat.aileron.AileronMixin",
     "compat.arselixirum.LivingEntityHooksMixin",
     "compat.deeperdarker.SoulElytraBoostPacketMixin",
-    "compat.extrasounds.SoundManagerMixin"
+    "compat.extrasounds.SoundManagerMixin",
+    "compat.netheriteextras.ModEventsMixin"
   ],
   "client": [
     "AbstractClientPlayerMixin",
@@ -31,6 +32,7 @@
     "MouseHandlerMixin",
     "PackSelectionModelMixin",
     "compat.deeperdarker.SoulElytraRendererMixin",
+    "compat.netheriteextras.TotemFloatingDisplayMixin",
     "compat.notes.EditNoteScreenMixin"
   ],
   "injectors": {

--- a/versions/1.21.10/gradle.properties
+++ b/versions/1.21.10/gradle.properties
@@ -17,3 +17,6 @@ arselixirum_version=0.2.2-neoforge
 fragmentum_version=0.0.13-neoforge
 extrasounds_version=1.4-neoforge,1.21.1
 aileron_version=1.21.1-neoforge-1.1.4
+netheriteextras_version=0.4.0+mc1.21
+connector_version=2.0.0-beta.11+1.21.1
+ffapi_version=0.115.6+2.1.4+1.21.1

--- a/versions/1.21.10/gradle.properties
+++ b/versions/1.21.10/gradle.properties
@@ -18,5 +18,3 @@ fragmentum_version=0.0.13-neoforge
 extrasounds_version=1.4-neoforge,1.21.1
 aileron_version=1.21.1-neoforge-1.1.4
 netheriteextras_version=0.4.0+mc1.21
-connector_version=2.0.0-beta.11+1.21.1
-ffapi_version=0.115.6+2.1.4+1.21.1


### PR DESCRIPTION
Note that an instance with connnector, ffapi, netherite extras, and rsb needs to be run to generate the remapped jars, probably don't need all these but I still did add all to :
- netheriteextras-0.4.0+mc1.21_mapped_moj_1.21.1.jar
- reinforced-shulker-boxes-3.2.1+1.21.1$reinforced-core-4.0.2+1.21.1$cloth-config-fabric-15.0.130-fabric$basic-math-0.6.1_mapped_moj_1.21.1.jar
- reinforced-shulker-boxes-3.2.1+1.21.1$reinforced-core-4.0.2+1.21.1$cloth-config-fabric-15.0.130-fabric_mapped_moj_1.21.1.jar
- reinforced-shulker-boxes-3.2.1+1.21.1$reinforced-core-4.0.2+1.21.1_mapped_moj_1.21.1.jar
- reinforced-shulker-boxes-3.2.1+1.21.1_mapped_moj_1.21.1.jar

then create the directory versions/1.21.1/fabric-remaps and put them in there, there probably is an easier way that I don't know about